### PR TITLE
Initialize skeleton expo project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+node_modules/
+.expo/
+.expo-shared/
+.env
+
+# Build outputs
+*.log
+dist/
+build/
+
+# macOS
+.DS_Store

--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { StatusBar } from 'expo-status-bar';
+import Navigation from './src/navigation';
+
+export default function App() {
+  return (
+    <>
+      <Navigation />
+      <StatusBar style="auto" />
+    </>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Memory Capsule
 
-A cross-platform (iOS, Android, Web) app for capturing, organizing, and sharing personal life stories as multimedia “capsules.” Built with Expo (React Native + Web) and Firebase for seamless media storage and privacy control.
+A cross-platform (iOS, Android, Web) app for capturing, organizing, and sharing
+personal life stories as multimedia “capsules.” Built with Expo (React Native +
+Web) and Firebase for seamless media storage and privacy control.
 
 ## Features
 - Guided storytelling prompts (text, audio, photo, video)
@@ -24,20 +26,19 @@ A cross-platform (iOS, Android, Web) app for capturing, organizing, and sharing 
 - TypeScript
 
 ## Getting Started
-1. **Clone the repo:**  
-   `git clone https://github.com/yourusername/memory-capsule.git`
-2. **Install dependencies:**  
-   `npm install`
-3. **Start the app:**  
-   `expo start`
-4. **Configure Firebase:**  
-   Add your Firebase config to `config/firebase.js` or as environment variables.
+1. **Install dependencies:** `npm install`
+2. **Start the app:** `npm start`
+3. **Configure Firebase:** create a `.env` file or use environment variables with
+   your Firebase credentials (see `src/config/firebase.ts`).
 
+The project uses Expo, so it can run on iOS, Android, or the web from a single
+codebase. Future features such as AI-assisted prompts and export functionality
+will plug into the modular folder structure under `src/features`.
 
 ## License
 [MIT License](LICENSE)
 
 ---
 
-**Contact:**  
-Created by [Sean at Memoria Films](https://memoriafilms.com/)  
+**Contact:**
+Created by [Sean at Memoria Films](https://memoriafilms.com/)

--- a/index.js
+++ b/index.js
@@ -1,0 +1,4 @@
+import { registerRootComponent } from 'expo';
+import App from './App';
+
+registerRootComponent(App);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "memory-capsule",
+  "version": "0.1.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "build": "expo build"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "expo-status-bar": "^1.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.72.4",
+    "react-native-web": "0.19.10",
+    "firebase": "^10.3.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.4"
+  }
+}

--- a/src/config/firebase.ts
+++ b/src/config/firebase.ts
@@ -1,0 +1,21 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
+
+const firebaseConfig = {
+  apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+
+export const auth = getAuth(app);
+export const db = getFirestore(app);
+export const storage = getStorage(app);
+
+export default app;

--- a/src/features/capsules/CapsuleScreen.tsx
+++ b/src/features/capsules/CapsuleScreen.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../navigation';
+
+export default function CapsuleScreen({ route }: NativeStackScreenProps<RootStackParamList, 'Capsule'>) {
+  const { id } = route.params;
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Capsule {id}</Text>
+      <Button title="Record Response" onPress={() => { /* TODO: implement */ }} />
+    </View>
+  );
+}

--- a/src/features/capsules/DashboardScreen.tsx
+++ b/src/features/capsules/DashboardScreen.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { View, Text, Button, FlatList, TouchableOpacity } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../navigation';
+
+interface Capsule {
+  id: string;
+  title: string;
+}
+
+const sampleCapsules: Capsule[] = [
+  { id: '1', title: 'My Childhood' },
+  { id: '2', title: 'College Years' },
+];
+
+export default function DashboardScreen({ navigation }: NativeStackScreenProps<RootStackParamList, 'Dashboard'>) {
+  const renderItem = ({ item }: { item: Capsule }) => (
+    <TouchableOpacity onPress={() => navigation.navigate('Capsule', { id: item.id })}>
+      <Text style={{ padding: 16 }}>{item.title}</Text>
+    </TouchableOpacity>
+  );
+
+  return (
+    <View style={{ flex: 1 }}>
+      <FlatList data={sampleCapsules} keyExtractor={(item) => item.id} renderItem={renderItem} />
+      <Button title="Create New Capsule" onPress={() => { /* TODO: implement */ }} />
+    </View>
+  );
+}

--- a/src/features/onboarding/OnboardingScreen.tsx
+++ b/src/features/onboarding/OnboardingScreen.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../navigation';
+
+export default function OnboardingScreen({ navigation }: NativeStackScreenProps<RootStackParamList, 'Onboarding'>) {
+  const handleContinue = () => {
+    navigation.replace('Dashboard');
+  };
+
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Welcome to Memory Capsule</Text>
+      <Button title="Continue" onPress={handleContinue} />
+    </View>
+  );
+}

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import OnboardingScreen from '../features/onboarding/OnboardingScreen';
+import DashboardScreen from '../features/capsules/DashboardScreen';
+import CapsuleScreen from '../features/capsules/CapsuleScreen';
+
+export type RootStackParamList = {
+  Onboarding: undefined;
+  Dashboard: undefined;
+  Capsule: { id: string };
+};
+
+const Stack = createNativeStackNavigator<RootStackParamList>();
+
+export default function Navigation() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen name="Onboarding" component={OnboardingScreen} />
+        <Stack.Screen name="Dashboard" component={DashboardScreen} />
+        <Stack.Screen name="Capsule" component={CapsuleScreen} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "esnext",
+    "jsx": "react",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["expo"],
+    "lib": ["es2015", "dom"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up expo + TypeScript project
- add Firebase initialization
- create example navigation stack and screens
- document setup in README

## Testing
- `npm test` *(fails: Missing script)*