### PR TITLE
Implement capsule sharing and responsive UI

### DIFF
--- a/App.test.tsx
+++ b/App.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react-native';
 import App from './App';
+jest.mock('@react-native-async-storage/async-storage', () => ({}));
 
 it('renders the root component without crashing', () => {
   render(<App />);

--- a/__mocks__/expo-linking.js
+++ b/__mocks__/expo-linking.js
@@ -1,0 +1,3 @@
+module.exports = {
+  createURL: (path) => `https://example.com${path}`,
+};

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
+import * as Linking from 'expo-linking';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import WelcomeScreen from '../src/features/onboarding/WelcomeScreen';
 import SignUpScreen from '../src/features/onboarding/SignUpScreen';
 import SignInScreen from '../src/features/onboarding/SignInScreen';
 import DashboardScreen from '../src/features/capsules/DashboardScreen';
 import CapsuleScreen from '../src/features/capsules/CapsuleScreen';
+import CapsuleView from '../src/features/capsules/CapsuleView';
 
 export type RootStackParamList = {
   Welcome: undefined;
@@ -13,19 +15,29 @@ export type RootStackParamList = {
   SignIn: undefined;
   Dashboard: undefined;
   Capsule: { id: string };
+  CapsuleView: { id: string };
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export default function Navigation() {
+  const linking = {
+    prefixes: [Linking.createURL('/')],
+    config: {
+      screens: {
+        CapsuleView: 'c/:id',
+      },
+    },
+  };
   return (
-    <NavigationContainer>
+    <NavigationContainer linking={linking}>
       <Stack.Navigator>
         <Stack.Screen name="Welcome" component={WelcomeScreen} />
         <Stack.Screen name="SignUp" component={SignUpScreen} />
         <Stack.Screen name="SignIn" component={SignInScreen} />
         <Stack.Screen name="Dashboard" component={DashboardScreen} />
         <Stack.Screen name="Capsule" component={CapsuleScreen} />
+        <Stack.Screen name="CapsuleView" component={CapsuleView} />
       </Stack.Navigator>
     </NavigationContainer>
   );

--- a/src/features/capsules/CapsuleScreen.tsx
+++ b/src/features/capsules/CapsuleScreen.tsx
@@ -1,15 +1,37 @@
 import React from 'react';
-import { View, Text, Button } from 'react-native';
+import { View, Text, Button, StyleSheet, useWindowDimensions } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../../navigation';
+import { spacing } from '../../theme';
+import { generateCapsuleShareLink } from './shareLink';
 
 export default function CapsuleScreen({ route }: NativeStackScreenProps<RootStackParamList, 'Capsule'>) {
   const { id } = route.params;
+  const { width } = useWindowDimensions();
+
+  const containerStyle = width >= 1024 ? styles.webContainer : width >= 768 ? styles.tabletContainer : styles.mobileContainer;
 
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Text>Capsule {id}</Text>
+    <View style={containerStyle}>
+      <Text style={styles.title}>Capsule {id}</Text>
       <Button title="Record Response" onPress={() => { /* TODO: implement */ }} />
+      <View style={styles.shareButton}>
+        <Button
+          title="Share Capsule"
+          onPress={() => {
+            const link = generateCapsuleShareLink(id);
+            console.log('Share link:', link);
+          }}
+        />
+      </View>
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  mobileContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: spacing.md },
+  tabletContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: spacing.lg },
+  webContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: spacing.lg * 2 },
+  title: { marginBottom: spacing.md },
+  shareButton: { marginTop: spacing.md },
+});

--- a/src/features/capsules/CapsuleView.test.tsx
+++ b/src/features/capsules/CapsuleView.test.tsx
@@ -1,0 +1,13 @@
+import { render } from '@testing-library/react-native';
+import CapsuleView from './CapsuleView';
+import { NavigationContainer } from '@react-navigation/native';
+
+it('renders capsule ID in read-only view', () => {
+  const component = (
+    <NavigationContainer>
+      <CapsuleView route={{ key: '1', name: 'CapsuleView', params: { id: '123' } }} navigation={undefined as any} />
+    </NavigationContainer>
+  );
+  const { getByText } = render(component);
+  expect(getByText('Shared Capsule 123')).toBeTruthy();
+});

--- a/src/features/capsules/CapsuleView.tsx
+++ b/src/features/capsules/CapsuleView.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { NativeStackScreenProps } from '@react-navigation/native-stack';
+import { RootStackParamList } from '../../../navigation';
+import { spacing } from '../../theme';
+
+/**
+ * Read-only view for shared capsules.
+ */
+export default function CapsuleView({ route }: NativeStackScreenProps<RootStackParamList, 'CapsuleView'>) {
+  const { id } = route.params;
+
+  // TODO: fetch capsule details from Firestore and check privacy settings
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Shared Capsule {id}</Text>
+      <Text>This capsule is view-only.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', alignItems: 'center', padding: spacing.lg },
+  title: { fontSize: 20, marginBottom: spacing.md },
+});

--- a/src/features/capsules/DashboardScreen.tsx
+++ b/src/features/capsules/DashboardScreen.tsx
@@ -1,29 +1,49 @@
 import React from 'react';
-import { View, Text, Button, FlatList, TouchableOpacity } from 'react-native';
+import { View, Text, Button, FlatList, TouchableOpacity, StyleSheet } from 'react-native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../../navigation';
+import { spacing } from '../../theme';
+import { generateCapsuleShareLink } from './shareLink';
 
 interface Capsule {
   id: string;
   title: string;
+  privacy: 'private' | 'unlisted' | 'public';
 }
 
 const sampleCapsules: Capsule[] = [
-  { id: '1', title: 'My Childhood' },
-  { id: '2', title: 'College Years' },
+  { id: '1', title: 'My Childhood', privacy: 'private' },
+  { id: '2', title: 'College Years', privacy: 'unlisted' },
 ];
 
 export default function DashboardScreen({ navigation }: NativeStackScreenProps<RootStackParamList, 'Dashboard'>) {
   const renderItem = ({ item }: { item: Capsule }) => (
-    <TouchableOpacity onPress={() => navigation.navigate('Capsule', { id: item.id })}>
-      <Text style={{ padding: 16 }}>{item.title}</Text>
+    <TouchableOpacity
+      style={styles.item}
+      onPress={() => navigation.navigate('Capsule', { id: item.id })}
+    >
+      <Text>{item.title}</Text>
+      {item.privacy !== 'private' && (
+        <Button
+          title="Share"
+          onPress={() => {
+            const link = generateCapsuleShareLink(item.id);
+            console.log('Share link:', link);
+          }}
+        />
+      )}
     </TouchableOpacity>
   );
 
   return (
-    <View style={{ flex: 1 }}>
+    <View style={styles.container}>
       <FlatList data={sampleCapsules} keyExtractor={(item) => item.id} renderItem={renderItem} />
       <Button title="Create New Capsule" onPress={() => { /* TODO: implement */ }} />
     </View>
   );
 }
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: spacing.md },
+  item: { padding: spacing.sm, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
+});

--- a/src/features/capsules/shareLink.test.ts
+++ b/src/features/capsules/shareLink.test.ts
@@ -1,0 +1,6 @@
+import { generateCapsuleShareLink } from './shareLink';
+
+it('generates share link with capsule id', () => {
+  const link = generateCapsuleShareLink('abc123');
+  expect(link).toContain('/c/abc123');
+});

--- a/src/features/capsules/shareLink.ts
+++ b/src/features/capsules/shareLink.ts
@@ -1,0 +1,9 @@
+import * as Linking from 'expo-linking';
+
+/**
+ * Generate an unlisted share link for a capsule.
+ */
+export function generateCapsuleShareLink(capsuleId: string): string {
+  const path = `/c/${capsuleId}`;
+  return Linking.createURL(path, { isTripleSlashed: false });
+}

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,18 @@
+export const colors = {
+  background: '#ffffff',
+  text: '#000000',
+  primary: '#6200ee',
+};
+
+export const spacing = {
+  xs: 4,
+  sm: 8,
+  md: 16,
+  lg: 24,
+};
+
+export const breakpoints = {
+  mobile: 0,
+  tablet: 768,
+  web: 1024,
+};


### PR DESCRIPTION
## Summary
- create theme tokens for responsive layout
- add share link generator for capsules
- create read-only CapsuleView screen
- wire share routes via navigation and linking config
- add share button to Dashboard and Capsule screens
- mock expo-linking for tests and fix App test
- ensure tests cover share link and CapsuleView

## Testing
- `npm test`